### PR TITLE
feat(settings): allow selection of default account for new conversations

### DIFF
--- a/basilisk/config.py
+++ b/basilisk/config.py
@@ -2,10 +2,12 @@ import logging
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
+from typing import Optional
 
 import yaml
 from platformdirs import user_config_path
 from pydantic import BaseModel, Extra, Field
+from pydantic.types import UUID4
 from pydantic_settings import (
 	BaseSettings,
 	PydanticBaseSettingsSource,
@@ -71,6 +73,7 @@ class GeneralSettings(BaseModel):
 	release_channel: ReleaseChannelEnum = Field(default=ReleaseChannelEnum.BETA)
 	last_update_check: datetime | None = Field(default=None)
 	quit_on_close: bool = Field(default=False)
+	default_account: Optional[UUID4] = Field(default=None)
 
 
 class ConversationSettings(BaseModel):

--- a/basilisk/gui/account_dialog.py
+++ b/basilisk/gui/account_dialog.py
@@ -760,6 +760,8 @@ class AccountDialog(wx.Dialog):
 			msg = _("Cannot remove account from environment variable")
 			wx.MessageBox(msg, _("Error"), wx.OK | wx.ICON_ERROR)
 			return
+		if account.id == conf.general.default_account:
+			conf.general.default_account = None
 		self.account_manager.remove(account)
 		self.account_list.DeleteItem(index)
 

--- a/basilisk/gui/conversation_tab.py
+++ b/basilisk/gui/conversation_tab.py
@@ -77,6 +77,7 @@ class ConversationTab(wx.Panel):
 		self._search_dialog = None
 		self.accounts_engines: dict[UUID, BaseEngine] = {}
 		self.init_ui()
+		self.select_default_account()
 		self.init_data()
 		self.update_ui()
 
@@ -273,6 +274,18 @@ class ConversationTab(wx.Panel):
 		sizer.Add(btn_sizer, proportion=0, flag=wx.EXPAND)
 
 		self.SetSizerAndFit(sizer)
+
+	def select_default_account(self):
+		if config.conf.general.default_account:
+			account_index = first(
+				locate(
+					config.conf.accounts,
+					lambda a: a.id == config.conf.general.default_account,
+				),
+				wx.NOT_FOUND,
+			)
+			if account_index != wx.NOT_FOUND:
+				self.account_combo.SetSelection(account_index)
 
 	def init_data(self):
 		self.on_account_change(None)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new optional attribute for user account settings, allowing specification of a default account.
	- Added functionality to automatically select a default account during the initialization of the conversation tab.
	- Enhanced the preferences dialog to manage user account preferences, including a combo box for selecting a default account.

- **Bug Fixes**
	- Improved handling of default account selection in the preferences dialog to ensure user choices are accurately captured.
	- Enhanced account removal process to prevent errors related to non-existent default accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->