### PR TITLE
feat: add option to control focus behavior after sending message

### DIFF
--- a/basilisk/config/main_config.py
+++ b/basilisk/config/main_config.py
@@ -38,6 +38,7 @@ class ConversationSettings(BaseModel):
 	nav_msg_select: bool = Field(default=False)
 	shift_enter_mode: bool = Field(default=False)
 	use_accessible_output: bool = Field(default=True)
+	focus_history_after_send: bool = Field(default=False)
 
 
 class ImagesSettings(BaseModel):

--- a/basilisk/gui/conversation_tab.py
+++ b/basilisk/gui/conversation_tab.py
@@ -1110,7 +1110,8 @@ class ConversationTab(wx.Panel, BaseConversation):
 			"new_block": new_block,
 			"stream": new_block.stream,
 		}
-		self.messages.SetFocus()
+		if config.conf().conversation.focus_history_after_send:
+			self.messages.SetFocus()
 		thread = self.task = threading.Thread(
 			target=self._handle_completion, kwargs=completion_kw
 		)
@@ -1198,7 +1199,7 @@ class ConversationTab(wx.Panel, BaseConversation):
 		text = self.stream_buffer
 		if (
 			self._speak_stream
-			and self.messages.HasFocus()
+			and (self.messages.HasFocus() or self.prompt.HasFocus())
 			and self.GetTopLevelParent().IsShown()
 		):
 			self._handle_accessible_output(text)
@@ -1215,6 +1216,8 @@ class ConversationTab(wx.Panel, BaseConversation):
 	def _post_completion_with_stream(self, new_block: MessageBlock):
 		self._flush_stream_buffer()
 		self._update_last_segment_length()
+		if config.conf().conversation.focus_history_after_send:
+			self.messages.SetFocus()
 		self._end_task()
 
 	def _post_completion_without_stream(self, new_block: MessageBlock):
@@ -1224,6 +1227,8 @@ class ConversationTab(wx.Panel, BaseConversation):
 		self.prompt.Clear()
 		self.image_files.clear()
 		self.refresh_images_list()
+		if config.conf().conversation.focus_history_after_send:
+			self.messages.SetFocus()
 		self._end_task()
 
 	def _end_task(self, success: bool = True):

--- a/basilisk/gui/preferences_dialog.py
+++ b/basilisk/gui/preferences_dialog.py
@@ -208,6 +208,14 @@ class PreferencesDialog(wx.Dialog):
 		)
 		conversation_group_sizer.Add(self.use_accessible_output, 0, wx.ALL, 5)
 
+		self.focus_history_checkbox = wx.CheckBox(
+			conversation_group, label=_("Focus message history after sending")
+		)
+		self.focus_history_checkbox.SetValue(
+			self.conf.conversation.focus_history_after_send
+		)
+		conversation_group_sizer.Add(self.focus_history_checkbox, 0, wx.ALL, 5)
+
 		sizer.Add(conversation_group_sizer, 0, wx.ALL, 5)
 
 		images_group = wx.StaticBox(panel, label=_("Images"))
@@ -358,6 +366,9 @@ class PreferencesDialog(wx.Dialog):
 		)
 		self.conf.conversation.use_accessible_output = (
 			self.use_accessible_output.GetValue()
+		)
+		self.conf.conversation.focus_history_after_send = (
+			self.focus_history_checkbox.GetValue()
 		)
 
 		self.conf.images.resize = self.image_resize.GetValue()


### PR DESCRIPTION
- Add new option `focus_history_after_send` in conversation settings
- Add checkbox in preferences dialog to control this behavior
- Update conversation tab to handle focus according to this setting
- Default behavior keeps focus on prompt after sending message

The option allows users to choose whether the focus should stay on the input field
or move to the message history after sending a message.

Fixes #405


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new setting to manage focus behavior after sending messages in conversation settings.
	- Added a checkbox in the preferences dialog for users to control message history focus after sending.

- **Improvements**
	- Enhanced the message submission process to respect user preferences for focus management.
	- Improved accessibility by ensuring output is directed based on user interaction.

- **Bug Fixes**
	- Maintained consistent error handling during message processing and focus management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->