### PR TITLE
feat: save and restore basilisk conversation

### DIFF
--- a/basilisk/__main__.py
+++ b/basilisk/__main__.py
@@ -6,7 +6,7 @@ import psutil
 
 from basilisk import global_vars
 from basilisk.consts import APP_NAME, FILE_LOCK_PATH, TMP_DIR
-from basilisk.file_watcher import send_focus_signal
+from basilisk.send_signal import send_focus_signal, send_open_bskc_file_signal
 from basilisk.singleton_instance import SingletonInstance
 
 
@@ -74,7 +74,10 @@ if __name__ == '__main__':
 				if global_vars.args.show_already_running_msg:
 					display_already_running_msg()
 				else:
-					send_focus_signal()
+					if global_vars.args.bskc_file:
+						send_open_bskc_file_signal(global_vars.args.bskc_file)
+					else:
+						send_focus_signal()
 				sys.exit(0)
 			except psutil.NoSuchProcess:
 				singleton_instance.acquire()

--- a/basilisk/__main__.py
+++ b/basilisk/__main__.py
@@ -53,6 +53,12 @@ def parse_args():
 		action="store_true",
 		dest="show_already_running_msg",
 	)
+	parser.add_argument(
+		'bskc_file',
+		nargs='?',
+		help='Basilisk conversation file to open',
+		default=None,
+	)
 	return parser.parse_args()
 
 

--- a/basilisk/config/conversation_profile.py
+++ b/basilisk/config/conversation_profile.py
@@ -15,7 +15,8 @@ from pydantic import (
 	model_validator,
 )
 
-from basilisk.provider import Provider, get_provider
+from basilisk.conversation import AIModelInfo
+from basilisk.provider import Provider
 
 from .account_config import Account, AccountInfo, get_account_config
 from .config_helper import (
@@ -33,9 +34,7 @@ class ConversationProfile(BaseModel):
 	name: str
 	system_prompt: str = Field(default="")
 	account_info: Optional[AccountInfo] = Field(default=None)
-	ai_model_info: Optional[str] = Field(
-		default=None, pattern=r"^[a-zA-Z]+/.+$"
-	)
+	ai_model_info: Optional[AIModelInfo] = Field(default=None)
 	max_tokens: Optional[int] = Field(default=None)
 	temperature: Optional[float] = Field(default=None)
 	top_p: Optional[float] = Field(default=None)
@@ -51,13 +50,12 @@ class ConversationProfile(BaseModel):
 			)
 			raise e
 
-	@field_validator("ai_model_info")
+	@field_validator("ai_model_info", mode="before")
 	@classmethod
-	def provider_must_exist(cls, value: str):
-		if value is None:
-			return None
-		provider_id, model_id = value.split("/", 1)
-		get_provider(id=provider_id)
+	def convert_ai_model(cls, value: Optional[str]) -> Optional[dict[str, str]]:
+		if isinstance(value, str):
+			provider_id, model_id = value.split("/", 1)
+			return {"provider_id": provider_id, "model_id": model_id}
 		return value
 
 	@classmethod
@@ -83,7 +81,7 @@ class ConversationProfile(BaseModel):
 	def ai_model_id(self) -> Optional[str]:
 		if self.ai_model_info is None:
 			return None
-		return self.ai_model_info.split("/", 1)[1]
+		return self.ai_model_info.model_id
 
 	@property
 	def ai_provider(self) -> Optional[Provider]:
@@ -92,11 +90,12 @@ class ConversationProfile(BaseModel):
 		if self.account:
 			return self.account.provider
 		if self.ai_model_info:
-			provider_id, model_id = self.ai_model_info.split("/", 1)
-			return get_provider(id=provider_id)
+			return self.ai_model_info.provider
 
 	def set_model_info(self, provider_id: str, model_id: str):
-		self.ai_model_info = f"{provider_id}/{model_id}"
+		self.ai_model_info = AIModelInfo(
+			provider_id=provider_id, model_id=model_id
+		)
 
 	def __eq__(self, value: Optional[ConversationProfile]) -> bool:
 		if value is None:
@@ -106,8 +105,7 @@ class ConversationProfile(BaseModel):
 	@model_validator(mode="after")
 	def check_same_provider(self) -> ConversationProfile:
 		if self.account is not None and self.ai_model_info is not None:
-			provider_id, model_id = self.ai_model_info.split("/", 1)
-			if provider_id != self.account.provider.id:
+			if self.ai_model_info.provider_id != self.account.provider.id:
 				raise ValueError(
 					"Model provider must be the same as account provider"
 				)

--- a/basilisk/config/conversation_profile.py
+++ b/basilisk/config/conversation_profile.py
@@ -15,8 +15,8 @@ from pydantic import (
 	model_validator,
 )
 
-from basilisk.conversation import AIModelInfo
 from basilisk.provider import Provider
+from basilisk.provider_ai_model import AIModelInfo
 
 from .account_config import Account, AccountInfo, get_account_config
 from .config_helper import (

--- a/basilisk/consts.py
+++ b/basilisk/consts.py
@@ -13,6 +13,9 @@ UNINSTALL_FILE_NAME = "unins000.exe"
 TMP_DIR = os.path.join(tempfile.gettempdir(), "basilisk")
 FILE_LOCK_PATH = os.path.join(TMP_DIR, "app.lock")
 
+FOCUS_FILE = os.path.join(TMP_DIR, "focus_file")
+OPEN_BSKC_FILE = os.path.join(TMP_DIR, "open_bskc_file")
+
 
 class HotkeyAction(Enum):
 	TOGGLE_VISIBILITY = 1

--- a/basilisk/conversation/__init__.py
+++ b/basilisk/conversation/__init__.py
@@ -1,4 +1,4 @@
-from .conversation_helper import PROMPT_TITLE, AIModelInfo
+from .conversation_helper import PROMPT_TITLE
 from .conversation_model import (
 	Conversation,
 	Message,
@@ -8,7 +8,6 @@ from .conversation_model import (
 from .image_model import URL_PATTERN, ImageFile, ImageFileTypes, NotImageError
 
 __all__ = [
-	"AIModelInfo",
 	"Conversation",
 	"ImageFile",
 	"ImageFileTypes",

--- a/basilisk/conversation/__init__.py
+++ b/basilisk/conversation/__init__.py
@@ -1,0 +1,20 @@
+from .conversation_model import (
+	PROMPT_TITLE,
+	Conversation,
+	Message,
+	MessageBlock,
+	MessageRoleEnum,
+)
+from .image_model import URL_PATTERN, ImageFile, ImageFileTypes, NotImageError
+
+__all__ = [
+	"Conversation",
+	"ImageFile",
+	"ImageFileTypes",
+	"Message",
+	"MessageBlock",
+	"MessageRoleEnum",
+	"NotImageError",
+	"PROMPT_TITLE",
+	"URL_PATTERN",
+]

--- a/basilisk/conversation/__init__.py
+++ b/basilisk/conversation/__init__.py
@@ -1,5 +1,5 @@
+from .conversation_helper import PROMPT_TITLE, AIModelInfo
 from .conversation_model import (
-	PROMPT_TITLE,
 	Conversation,
 	Message,
 	MessageBlock,
@@ -8,6 +8,7 @@ from .conversation_model import (
 from .image_model import URL_PATTERN, ImageFile, ImageFileTypes, NotImageError
 
 __all__ = [
+	"AIModelInfo",
 	"Conversation",
 	"ImageFile",
 	"ImageFileTypes",

--- a/basilisk/conversation/conversation_helper.py
+++ b/basilisk/conversation/conversation_helper.py
@@ -6,41 +6,17 @@ import zipfile
 from typing import TYPE_CHECKING
 
 from fsspec.implementations.zip import ZipFileSystem
-from pydantic import BaseModel, Field, field_validator
 from upath import UPath
 
 from .image_model import ImageFile, ImageFileTypes
 
 if TYPE_CHECKING:
-	from basilisk.provider import Provider
-
 	from .conversation_model import Conversation
 
 
 log = logging.getLogger(__name__)
 
 PROMPT_TITLE = "Generate a concise, relevant title in the conversation's main language based on the topics and context. Max 70 characters. Do not surround the text with quotation marks."
-
-
-class AIModelInfo(BaseModel):
-	provider_id: str = Field(pattern=r"^[a-zA-Z]+$")
-	model_id: str = Field(pattern=r"^.+$")
-
-	@staticmethod
-	def get_provider_by_id(provider_id: str) -> Provider:
-		from basilisk.provider import get_provider
-
-		return get_provider(id=provider_id)
-
-	@field_validator("provider_id", mode="after")
-	@classmethod
-	def provider_must_exist(cls, value: str) -> str:
-		cls.get_provider_by_id(value)
-		return value
-
-	@property
-	def provider(self) -> Provider:
-		return self.get_provider_by_id(self.provider_id)
 
 
 def save_attachments(

--- a/basilisk/conversation/conversation_helper.py
+++ b/basilisk/conversation/conversation_helper.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 from fsspec.implementations.zip import ZipFileSystem
 from upath import UPath
 
+from basilisk.config import conf
+
 from .image_model import ImageFile, ImageFileTypes
 
 if TYPE_CHECKING:
@@ -60,6 +62,13 @@ def restore_attachments(attachments: list[ImageFile], storage_path: UPath):
 			with new_path.open(mode="wb") as new_file:
 				shutil.copyfileobj(attachment_file, new_file)
 		attachment.location = new_path
+		if conf().images.resize:
+			attachment.resize(
+				storage_path,
+				conf().images.max_width,
+				conf().images.max_height,
+				conf().images.quality,
+			)
 
 
 def read_conv_main_file(

--- a/basilisk/conversation/conversation_helper.py
+++ b/basilisk/conversation/conversation_helper.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+import logging
+import zipfile
 from typing import TYPE_CHECKING
 
+from fsspec.implementations.zip import ZipFileSystem
 from pydantic import BaseModel, Field, field_validator
 
 if TYPE_CHECKING:
 	from basilisk.provider import Provider
+
+	from .conversation_model import Conversation
+
+log = logging.getLogger(__name__)
 
 PROMPT_TITLE = "Generate a concise, relevant title in the conversation's main language based on the topics and context. Max 70 characters. Do not surround the text with quotation marks."
 
@@ -23,8 +30,25 @@ class AIModelInfo(BaseModel):
 	@field_validator("provider_id", mode="after")
 	@classmethod
 	def provider_must_exist(cls, value: str) -> str:
-		return cls.get_provider_by_id(value)
+		cls.get_provider_by_id(value)
+		return value
 
 	@property
 	def provider(self) -> Provider:
 		return self.get_provider_by_id(self.provider_id)
+
+
+def create_conv_main_file(conversation: Conversation, fs: ZipFileSystem):
+	with fs.open("conversation.json", mode="w") as conv_file:
+		conv_json = conversation.model_dump_json()
+		conv_file.write(conv_json)
+
+
+def create_bskc_file(conversation: Conversation, file_path: str):
+	"""Save a conversation to a Basilisk Conversation file."""
+	with open(file_path, mode="w+b") as bskc_file:
+		fs = ZipFileSystem(
+			fo=bskc_file, mode="w", compression=zipfile.ZIP_STORED
+		)
+		create_conv_main_file(conversation, fs)
+		fs.close()

--- a/basilisk/conversation/conversation_helper.py
+++ b/basilisk/conversation/conversation_helper.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field, field_validator
+
+if TYPE_CHECKING:
+	from basilisk.provider import Provider
+
+PROMPT_TITLE = "Generate a concise, relevant title in the conversation's main language based on the topics and context. Max 70 characters. Do not surround the text with quotation marks."
+
+
+class AIModelInfo(BaseModel):
+	provider_id: str = Field(pattern=r"^[a-zA-Z]+$")
+	model_id: str = Field(pattern=r"^.+$")
+
+	@staticmethod
+	def get_provider_by_id(provider_id: str) -> Provider:
+		from basilisk.provider import get_provider
+
+		return get_provider(id=provider_id)
+
+	@field_validator("provider_id", mode="after")
+	@classmethod
+	def provider_must_exist(cls, value: str) -> str:
+		return cls.get_provider_by_id(value)
+
+	@property
+	def provider(self) -> Provider:
+		return self.get_provider_by_id(self.provider_id)

--- a/basilisk/conversation/conversation_helper.py
+++ b/basilisk/conversation/conversation_helper.py
@@ -4,8 +4,8 @@ import logging
 import zipfile
 from typing import TYPE_CHECKING
 
+from fsspec.implementations.zip import ZipFileSystem
 from pydantic import BaseModel, Field, field_validator
-from upath import UPath
 
 if TYPE_CHECKING:
 	from basilisk.provider import Provider
@@ -39,28 +39,27 @@ class AIModelInfo(BaseModel):
 		return self.get_provider_by_id(self.provider_id)
 
 
-def create_conv_main_file(conversation: Conversation, zip_base_path: UPath):
-	conv_main_path = zip_base_path / "conversation.json"
-	with conv_main_path.open(mode="w") as conv_file:
+def create_conv_main_file(conversation: Conversation, fs: ZipFileSystem):
+	with fs.open("conversation.json", mode="w") as conv_file:
 		conv_json = conversation.model_dump_json()
 		conv_file.write(conv_json)
 
 
 def read_conv_main_file(
-	model_cls: Conversation, conv_file: UPath
+	model_cls: Conversation, fs: ZipFileSystem
 ) -> Conversation:
-	with conv_file.open(mode="r") as conv_file:
+	with fs.open("conversation.json", mode="r") as conv_file:
 		return model_cls.model_validate_json(conv_file.read())
 
 
 def create_bskc_file(conversation: Conversation, file_path: str):
 	"""Save a conversation to a Basilisk Conversation file."""
 	with open(file_path, mode="w+b") as bskc_file:
-		zip_base_path = UPath(
-			"zip://.", mode="w", fo=bskc_file, compression=zipfile.ZIP_STORED
+		fs = ZipFileSystem(
+			fo=bskc_file, mode="w", compression=zipfile.ZIP_STORED
 		)
-		create_conv_main_file(conversation, zip_base_path)
-		zip_base_path.fs.close()
+		create_conv_main_file(conversation, fs)
+		fs.close()
 
 
 def open_bskc_file(model_cls: Conversation, file_path: str) -> Conversation:
@@ -68,10 +67,9 @@ def open_bskc_file(model_cls: Conversation, file_path: str) -> Conversation:
 	with open(file_path, mode="r+b") as bskc_file:
 		if not zipfile.is_zipfile(bskc_file):
 			raise zipfile.BadZipFile("The baskc file must be a zip archive.")
-		zip_base_path = UPath("zip://.", mode="r", fo=bskc_file)
-		conv_main_path = zip_base_path / "conversation.json"
-		if not conv_main_path.exists():
+		fs = ZipFileSystem(fo=bskc_file, mode="r")
+		if not fs.exists("conversation.json"):
 			raise FileNotFoundError(
 				"The baskc file must contain a conversation.json file."
 			)
-		return read_conv_main_file(model_cls, conv_main_path)
+		return read_conv_main_file(model_cls, fs)

--- a/basilisk/conversation/conversation_helper.py
+++ b/basilisk/conversation/conversation_helper.py
@@ -9,6 +9,7 @@ from fsspec.implementations.zip import ZipFileSystem
 from upath import UPath
 
 from basilisk.config import conf
+from basilisk.decorators import measure_time
 
 from .image_model import ImageFile, ImageFileTypes
 
@@ -88,6 +89,7 @@ def read_conv_main_file(
 	return conversation
 
 
+@measure_time
 def create_bskc_file(conversation: Conversation, file_path: str):
 	"""Save a conversation to a Basilisk Conversation file."""
 	with open(file_path, mode="w+b") as bskc_file:
@@ -98,6 +100,7 @@ def create_bskc_file(conversation: Conversation, file_path: str):
 		fs.close()
 
 
+@measure_time
 def open_bskc_file(
 	model_cls: Conversation, file_path: str, base_storage_path: UPath
 ) -> Conversation:

--- a/basilisk/conversation/conversation_model.py
+++ b/basilisk/conversation/conversation_model.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 from pydantic import BaseModel, Field
 
-from .conversation_helper import AIModelInfo
+from .conversation_helper import AIModelInfo, create_bskc_file
 from .image_model import ImageFile
 
 
@@ -45,3 +45,6 @@ class Conversation(BaseModel):
 	system: Message | None = Field(default=None)
 	messages: list[MessageBlock] = Field(default_factory=list)
 	title: str | None = Field(default=None)
+
+	def save(self, file_path: str):
+		create_bskc_file(self, file_path)

--- a/basilisk/conversation/conversation_model.py
+++ b/basilisk/conversation/conversation_model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from .conversation_helper import AIModelInfo, create_bskc_file, open_bskc_file
 from .image_model import ImageFile
@@ -31,6 +31,13 @@ class MessageBlock(BaseModel):
 	stream: bool = Field(default=False)
 	created_at: datetime = Field(default_factory=datetime.now)
 	updated_at: datetime = Field(default_factory=datetime.now)
+
+	@field_validator("response", mode="after")
+	@classmethod
+	def no_attachment_in_response(cls, value: Message | None) -> Message | None:
+		if value and value.attachments:
+			raise ValueError("Response messages cannot have attachments.")
+		return value
 
 	def __init__(self, /, **data):
 		provider_id = data.pop("provider_id", None)

--- a/basilisk/conversation/conversation_model.py
+++ b/basilisk/conversation/conversation_model.py
@@ -1,11 +1,11 @@
 from datetime import datetime
 from enum import Enum
-from typing import Literal
 
 from pydantic import BaseModel, Field
 
-from .image_file import ImageFile
-from .provider_ai_model import ProviderAIModel
+from basilisk.provider_ai_model import ProviderAIModel
+
+from .image_model import ImageFile
 
 PROMPT_TITLE = "Generate a concise, relevant title in the conversation's main language based on the topics and context. Max 70 characters. Do not surround the text with quotation marks."
 
@@ -14,16 +14,6 @@ class MessageRoleEnum(Enum):
 	ASSISTANT = "assistant"
 	USER = "user"
 	SYSTEM = "system"
-
-
-class ImageUrlMessageContent(BaseModel):
-	type: Literal["image_url"]
-	image_url: dict[str, str]
-
-
-class TextMessageContent(BaseModel):
-	type: Literal["text"]
-	text: str
 
 
 class Message(BaseModel):

--- a/basilisk/conversation/conversation_model.py
+++ b/basilisk/conversation/conversation_model.py
@@ -3,11 +3,8 @@ from enum import Enum
 
 from pydantic import BaseModel, Field
 
-from basilisk.provider_ai_model import ProviderAIModel
-
+from .conversation_helper import AIModelInfo
 from .image_model import ImageFile
-
-PROMPT_TITLE = "Generate a concise, relevant title in the conversation's main language based on the topics and context. Max 70 characters. Do not surround the text with quotation marks."
 
 
 class MessageRoleEnum(Enum):
@@ -25,13 +22,23 @@ class Message(BaseModel):
 class MessageBlock(BaseModel):
 	request: Message
 	response: Message | None = Field(default=None)
-	model: ProviderAIModel
+	model: AIModelInfo
 	temperature: float = Field(default=1)
 	max_tokens: int = Field(default=4096)
 	top_p: float = Field(default=1)
 	stream: bool = Field(default=False)
 	created_at: datetime = Field(default_factory=datetime.now)
 	updated_at: datetime = Field(default_factory=datetime.now)
+
+	def __init__(self, /, **data):
+		provider_id = data.pop("provider_id", None)
+		model_id = data.pop("model_id", None)
+		model = data.get("model", None)
+		if provider_id and model_id and not model:
+			data["model"] = AIModelInfo(
+				provider_id=provider_id, model_id=model_id
+			)
+		super().__init__(**data)
 
 
 class Conversation(BaseModel):

--- a/basilisk/conversation/conversation_model.py
+++ b/basilisk/conversation/conversation_model.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from enum import Enum
 
 from pydantic import BaseModel, Field, field_validator
+from upath import UPath
 
 from .conversation_helper import AIModelInfo, create_bskc_file, open_bskc_file
 from .image_model import ImageFile
@@ -49,6 +50,8 @@ class MessageBlock(BaseModel):
 			)
 		super().__init__(**data)
 
+	__init__.__pydantic_base_init__ = True
+
 
 class Conversation(BaseModel):
 	system: Message | None = Field(default=None)
@@ -56,8 +59,8 @@ class Conversation(BaseModel):
 	title: str | None = Field(default=None)
 
 	@classmethod
-	def open(cls, file_path: str) -> Conversation:
-		return open_bskc_file(cls, file_path)
+	def open(cls, file_path: str, base_storage_path: UPath) -> Conversation:
+		return open_bskc_file(cls, file_path, base_storage_path)
 
 	def save(self, file_path: str):
 		create_bskc_file(self, file_path)

--- a/basilisk/conversation/conversation_model.py
+++ b/basilisk/conversation/conversation_model.py
@@ -6,7 +6,9 @@ from enum import Enum
 from pydantic import BaseModel, Field, field_validator
 from upath import UPath
 
-from .conversation_helper import AIModelInfo, create_bskc_file, open_bskc_file
+from basilisk.provider_ai_model import AIModelInfo
+
+from .conversation_helper import create_bskc_file, open_bskc_file
 from .image_model import ImageFile
 
 

--- a/basilisk/conversation/conversation_model.py
+++ b/basilisk/conversation/conversation_model.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 from datetime import datetime
 from enum import Enum
 
 from pydantic import BaseModel, Field
 
-from .conversation_helper import AIModelInfo, create_bskc_file
+from .conversation_helper import AIModelInfo, create_bskc_file, open_bskc_file
 from .image_model import ImageFile
 
 
@@ -45,6 +47,10 @@ class Conversation(BaseModel):
 	system: Message | None = Field(default=None)
 	messages: list[MessageBlock] = Field(default_factory=list)
 	title: str | None = Field(default=None)
+
+	@classmethod
+	def open(cls, file_path: str) -> Conversation:
+		return open_bskc_file(cls, file_path)
 
 	def save(self, file_path: str):
 		create_bskc_file(self, file_path)

--- a/basilisk/conversation/image_model.py
+++ b/basilisk/conversation/image_model.py
@@ -13,7 +13,7 @@ from PIL import Image
 from pydantic import BaseModel, PlainValidator
 from upath import UPath
 
-from .decorators import measure_time
+from basilisk.decorators import measure_time
 
 log = logging.getLogger(__name__)
 

--- a/basilisk/conversation/image_model.py
+++ b/basilisk/conversation/image_model.py
@@ -214,16 +214,14 @@ class ImageFile(BaseModel):
 
 	@measure_time
 	def resize(
-		self,
-		optimize_folder: UPath,
-		max_width: int,
-		max_height: int,
-		quality: int,
+		self, conv_folder: UPath, max_width: int, max_height: int, quality: int
 	):
 		if ImageFileTypes.IMAGE_URL == self.type:
 			return
 		log.debug("Resizing image")
-		resize_location = optimize_folder / self.location.name
+		resize_location = conv_folder.joinpath(
+			"optimized_images", self.location.name
+		)
 		with self.location.open(mode="rb") as src_file:
 			with resize_location.open(mode="wb") as dst_file:
 				success = resize_image(

--- a/basilisk/conversation/image_model.py
+++ b/basilisk/conversation/image_model.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any
 
 import httpx
 from PIL import Image
-from pydantic import BaseModel, PlainValidator
+from pydantic import BaseModel, Field, PlainValidator
 from upath import UPath
 
 from basilisk.decorators import measure_time
@@ -102,7 +102,7 @@ class ImageFile(BaseModel):
 	description: str | None = None
 	size: int | None = None
 	dimensions: tuple[int, int] | None = None
-	resize_location: PydanticUPath | None = None
+	resize_location: PydanticUPath | None = Field(default=None, exclude=True)
 
 	@classmethod
 	@measure_time

--- a/basilisk/file_watcher.py
+++ b/basilisk/file_watcher.py
@@ -25,18 +25,26 @@ class FileWatcher(FileSystemEventHandler):
 
 	def on_modified(self, event: FileSystemEvent):
 		if event.src_path == FOCUS_FILE:
-			logger.debug("Focus file modified")
-			if event.src_path not in self.last_modified:
-				self.last_modified[event.src_path] = 0
-			elif time.time() - self.last_modified[event.src_path] > 1:
-				self.last_modified[event.src_path] = time.time()
-				logger.debug("Sending focus")
-				CallAfter(self.send_focus)
+			self.on_focus_file(event)
 		elif event.src_path == OPEN_BSKC_FILE:
-			logger.debug("Open bskc file modified")
-			with open(event.src_path, 'r') as f:
-				logger.debug("Opening basilisk conversation")
-				CallAfter(self.open_bskc, f.read())
+			self.on_open_bskc_file(event)
+		else:
+			logger.error(f"unknown event: {event}")
+
+	def on_focus_file(self, event: FileSystemEvent):
+		logger.debug("Focus file modified")
+		if event.src_path not in self.last_modified:
+			self.last_modified[event.src_path] = 0
+		elif time.time() - self.last_modified[event.src_path] > 1:
+			self.last_modified[event.src_path] = time.time()
+		logger.debug("Sending focus")
+		CallAfter(self.send_focus)
+
+	def on_open_bskc_file(self, event: FileSystemEvent):
+		logger.debug("Open bskc file modified")
+		with open(event.src_path, 'r') as f:
+			logger.debug("Opening basilisk conversation")
+			CallAfter(self.open_bskc, f.read())
 
 
 def init_file_watcher(**callbacks) -> BaseObserverSubclassCallable:

--- a/basilisk/file_watcher.py
+++ b/basilisk/file_watcher.py
@@ -1,41 +1,49 @@
 from __future__ import annotations
 
-import os
+import logging
 import time
 from typing import TYPE_CHECKING, Callable
 
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
+from wx import CallAfter
 
 if TYPE_CHECKING:
 	from watchdog.events import FileSystemEvent
 	from watchdog.observers import BaseObserverSubclassCallable
-from basilisk.consts import TMP_DIR
+from basilisk.consts import FOCUS_FILE, OPEN_BSKC_FILE, TMP_DIR
+
+logger = logging.getLogger(__name__)
 
 
 class FileWatcher(FileSystemEventHandler):
 	last_modified = {}
 
-	def __init__(self, callback: Callable):
-		self.callback = callback
+	def __init__(self, callbacks: dict[str, Callable]):
+		for name, callback in callbacks.items():
+			setattr(self, name, callback)
 
 	def on_modified(self, event: FileSystemEvent):
-		if event.src_path == os.path.join(TMP_DIR, "focus_file"):
+		if event.src_path == FOCUS_FILE:
+			logger.debug("Focus file modified")
 			if event.src_path not in self.last_modified:
 				self.last_modified[event.src_path] = 0
 			elif time.time() - self.last_modified[event.src_path] > 1:
 				self.last_modified[event.src_path] = time.time()
-				self.callback()
+				logger.debug("Sending focus")
+				CallAfter(self.send_focus)
+		elif event.src_path == OPEN_BSKC_FILE:
+			logger.debug("Open bskc file modified")
+			with open(event.src_path, 'r') as f:
+				logger.debug("Opening basilisk conversation")
+				CallAfter(self.open_bskc, f.read())
 
 
-def send_focus_signal():
-	with open(os.path.join(TMP_DIR, "focus_file"), 'w') as f:
-		f.write(str(time.time()))
-
-
-def init_file_watcher(callback: Callable) -> BaseObserverSubclassCallable:
-	event_handler = FileWatcher(callback)
+def init_file_watcher(**callbacks) -> BaseObserverSubclassCallable:
+	event_handler = FileWatcher(callbacks)
 	observer = Observer()
 	observer.schedule(event_handler, TMP_DIR, recursive=False)
+	logger.debug("Starting file watcher")
 	observer.start()
+
 	return observer

--- a/basilisk/gui/conversation_tab.py
+++ b/basilisk/gui/conversation_tab.py
@@ -1285,3 +1285,6 @@ class ConversationTab(wx.Panel, BaseConversation):
 			return
 		finally:
 			stop_sound()
+
+	def save_conversation(self, file_path: str):
+		log.debug(f"Saving conversation to {file_path}")

--- a/basilisk/gui/conversation_tab.py
+++ b/basilisk/gui/conversation_tab.py
@@ -1081,7 +1081,7 @@ class ConversationTab(wx.Panel, BaseConversation):
 		if config.conf().images.resize:
 			for image in self.image_files:
 				image.resize(
-					self.conv_storage_path / "optimized_images",
+					self.conv_storage_path,
 					config.conf().images.max_width,
 					config.conf().images.max_height,
 					config.conf().images.quality,

--- a/basilisk/gui/conversation_tab.py
+++ b/basilisk/gui/conversation_tab.py
@@ -1075,7 +1075,8 @@ class ConversationTab(wx.Panel, BaseConversation):
 				content=self.prompt.GetValue(),
 				attachments=self.image_files,
 			),
-			model=model,
+			model_id=model.id,
+			provider_id=self.current_account.provider.id,
 			temperature=self.temperature_spinner.GetValue(),
 			top_p=self.top_p_spinner.GetValue(),
 			max_tokens=self.max_tokens_spin_ctrl.GetValue(),
@@ -1251,7 +1252,8 @@ class ConversationTab(wx.Panel, BaseConversation):
 				request=Message(
 					role=MessageRoleEnum.USER, content=PROMPT_TITLE
 				),
-				model=model,
+				provider_id=self.current_account.provider.id,
+				model_id=model.id,
 				temperature=self.temperature_spinner.GetValue(),
 				top_p=self.top_p_spinner.GetValue(),
 				max_tokens=self.max_tokens_spin_ctrl.GetValue(),

--- a/basilisk/gui/conversation_tab.py
+++ b/basilisk/gui/conversation_tab.py
@@ -19,15 +19,15 @@ from basilisk import global_vars
 from basilisk.accessible_output import clear_for_speak, get_accessible_output
 from basilisk.conversation import (
 	PROMPT_TITLE,
+	URL_PATTERN,
 	Conversation,
-	ImageUrlMessageContent,
+	ImageFile,
 	Message,
 	MessageBlock,
 	MessageRoleEnum,
-	TextMessageContent,
+	NotImageError,
 )
 from basilisk.decorators import ensure_no_task_running
-from basilisk.image_file import URL_PATTERN, ImageFile, NotImageError
 from basilisk.message_segment_manager import (
 	MessageSegment,
 	MessageSegmentManager,
@@ -850,16 +850,9 @@ class ConversationTab(wx.Panel, BaseConversation):
 			last_user_message = self.conversation.messages[-1].request.content
 			self.prompt.SetValue(last_user_message)
 
-	def extract_text_from_message(
-		self, content: list[TextMessageContent | ImageUrlMessageContent] | str
-	) -> str:
+	def extract_text_from_message(self, content: str) -> str:
 		if isinstance(content, str):
 			return content
-		text = ""
-		for item in content:
-			if item.type == "text":
-				text += item.text
-		return text
 
 	def append_text_and_create_segment(
 		self, text, segment_type, new_block_ref, absolute_length
@@ -1288,3 +1281,4 @@ class ConversationTab(wx.Panel, BaseConversation):
 
 	def save_conversation(self, file_path: str):
 		log.debug(f"Saving conversation to {file_path}")
+		self.conversation.save(file_path)

--- a/basilisk/gui/main_frame.py
+++ b/basilisk/gui/main_frame.py
@@ -86,7 +86,7 @@ class MainFrame(wx.Frame):
 			# Translators: A label for a menu item to save a conversation
 			_("Save conversation") + "\tCtrl+S",
 		)
-		save_conversation_item.Enable(False)
+		self.Bind(wx.EVT_MENU, self.save_conversation, save_conversation_item)
 		save_as_conversation_item = conversation_menu.Append(
 			wx.ID_ANY,
 			# Translators: A label for a menu item to save a conversation as a new file
@@ -722,3 +722,21 @@ class MainFrame(wx.Frame):
 		)
 		if first_account_msg == wx.YES:
 			self.on_manage_accounts(None)
+
+	def save_conversation(self, event):
+		current_tab = self.current_tab
+		if not current_tab:
+			wx.MessageBox(
+				_("No conversation selected"), _("Error"), wx.OK | wx.ICON_ERROR
+			)
+			return
+		file_dialog = wx.FileDialog(
+			self,
+			# Translators: A title for the save conversation dialog
+			message=_("Save conversation"),
+			wildcard=_("Basilisk conversation files") + "(*.bskc)|*.bskc",
+			style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
+		)
+		if file_dialog.ShowModal() == wx.ID_OK:
+			current_tab.save_conversation(file_dialog.GetPath())
+		file_dialog.Destroy()

--- a/basilisk/gui/main_frame.py
+++ b/basilisk/gui/main_frame.py
@@ -14,7 +14,7 @@ if sys.platform == 'win32':
 import basilisk.config as config
 from basilisk import global_vars
 from basilisk.consts import APP_NAME, APP_SOURCE_URL, HotkeyAction
-from basilisk.image_file import ImageFile
+from basilisk.conversation import ImageFile
 from basilisk.logger import get_log_file_path
 from basilisk.screen_capture_thread import CaptureMode, ScreenCaptureThread
 from basilisk.updater import BaseUpdater

--- a/basilisk/gui/main_frame.py
+++ b/basilisk/gui/main_frame.py
@@ -277,7 +277,9 @@ class MainFrame(wx.Frame):
 			return
 		now = datetime.datetime.now()
 		capture_name = f"capture_{now.isoformat(timespec='seconds')}.png"
-		capture_path = conv_tab.conv_storage_url / f"attachments/{capture_name}"
+		capture_path = (
+			conv_tab.conv_storage_path / f"attachments/{capture_name}"
+		)
 		name = name or capture_name
 		log.debug(f"Capture file URL: {capture_path}")
 		thread = ScreenCaptureThread(

--- a/basilisk/main_app.py
+++ b/basilisk/main_app.py
@@ -54,7 +54,11 @@ class MainApp(wx.App):
 		if global_vars.args.minimize:
 			frame_style |= wx.MINIMIZE
 		self.frame = MainFrame(
-			None, title=APP_NAME, conf=self.conf, style=frame_style
+			None,
+			title=APP_NAME,
+			conf=self.conf,
+			style=frame_style,
+			open_file=global_vars.args.bskc_file,
 		)
 		self.frame.Show(not global_vars.args.minimize)
 		self.SetTopWindow(self.frame)

--- a/basilisk/main_app.py
+++ b/basilisk/main_app.py
@@ -63,7 +63,10 @@ class MainApp(wx.App):
 		self.frame.Show(not global_vars.args.minimize)
 		self.SetTopWindow(self.frame)
 		self.init_system_cert_store()
-		self.file_watcher = init_file_watcher(self.bring_window_to_focus)
+		self.file_watcher = init_file_watcher(
+			send_focus=self.bring_window_to_focus,
+			open_bskc=self.frame.open_conversation,
+		)
 		self.server = None
 		if self.conf.server.enable:
 			self.server = ServerThread(self.frame, self.conf.server.port)
@@ -112,13 +115,12 @@ class MainApp(wx.App):
 			self.stop_auto_update = True
 			self.auto_update.join()
 			log.info("Automatic update thread stopped")
-		log.debug("Removing temporary files")
-		shutil.rmtree(TMP_DIR, ignore_errors=True)
-
 		log.debug("Stopping file watcher")
 		self.file_watcher.stop()
 		self.file_watcher.join()
-		log.debug("File watcher stopped")
+		log.info("File watcher stopped")
+		log.debug("Removing temporary files")
+		shutil.rmtree(TMP_DIR, ignore_errors=True)
 
 		log.info("Application exited")
 		return 0

--- a/basilisk/provider.py
+++ b/basilisk/provider.py
@@ -4,10 +4,12 @@ import logging
 from dataclasses import dataclass, field
 from enum import Enum
 from functools import cached_property
-from typing import Any, Iterable, Optional, Type
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Type
 
 from .decorators import measure_time
-from .provider_engine.base_engine import BaseEngine
+
+if TYPE_CHECKING:
+	from .provider_engine.base_engine import BaseEngine
 
 log = logging.getLogger(__name__)
 

--- a/basilisk/provider_engine/anthropic_engine.py
+++ b/basilisk/provider_engine/anthropic_engine.py
@@ -182,12 +182,12 @@ class AnthropicEngine(BaseEngine):
 		**kwargs,
 	) -> Message | Stream[MessageStreamEvent]:
 		super().completion(new_block, conversation, system_message, **kwargs)
+		model = self.get_model(new_block.model.model_id)
 		params = {
-			"model": new_block.model.id,
+			"model": model.id,
 			"messages": self.get_messages(new_block, conversation),
 			"temperature": new_block.temperature,
-			"max_tokens": new_block.max_tokens
-			or new_block.model.max_output_tokens,
+			"max_tokens": new_block.max_tokens or model.max_output_tokens,
 			"top_p": new_block.top_p,
 			"stream": new_block.stream,
 		}

--- a/basilisk/provider_engine/anthropic_engine.py
+++ b/basilisk/provider_engine/anthropic_engine.py
@@ -11,11 +11,11 @@ from anthropic.types.image_block_param import ImageBlockParam, Source
 
 from basilisk.conversation import (
 	Conversation,
+	ImageFileTypes,
 	Message,
 	MessageBlock,
 	MessageRoleEnum,
 )
-from basilisk.image_file import ImageFileTypes
 
 if TYPE_CHECKING:
 	from anthropic._streaming import Stream

--- a/basilisk/provider_engine/gemini_engine.py
+++ b/basilisk/provider_engine/gemini_engine.py
@@ -8,11 +8,12 @@ import google.generativeai as genai
 
 from basilisk.conversation import (
 	Conversation,
+	ImageFile,
+	ImageFileTypes,
 	Message,
 	MessageBlock,
 	MessageRoleEnum,
 )
-from basilisk.image_file import ImageFile, ImageFileTypes
 
 from .base_engine import BaseEngine, ProviderAIModel, ProviderCapability
 

--- a/basilisk/provider_engine/gemini_engine.py
+++ b/basilisk/provider_engine/gemini_engine.py
@@ -160,7 +160,7 @@ class GeminiEngine(BaseEngine):
 	) -> genai.types.GenerateContentResponse:
 		super().completion(new_block, conversation, system_message, **kwargs)
 		model = genai.GenerativeModel(
-			model_name=new_block.model.id,
+			model_name=new_block.model.model_id,
 			system_instruction=system_message.content
 			if system_message
 			else None,

--- a/basilisk/provider_engine/openai_engine.py
+++ b/basilisk/provider_engine/openai_engine.py
@@ -299,7 +299,7 @@ class OpenAIEngine(BaseEngine):
 	) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
 		super().completion(new_block, conversation, system_message, **kwargs)
 		params = {
-			"model": new_block.model.id,
+			"model": new_block.model.model_id,
 			"messages": self.get_messages(
 				new_block, conversation, system_message
 			),

--- a/basilisk/recording_thread.py
+++ b/basilisk/recording_thread.py
@@ -14,7 +14,7 @@ from numpy import array as np_array
 
 if TYPE_CHECKING:
 	from basilisk.config.main_config import RecordingsSettings
-	from basilisk.conversation import ConversationTab
+	from basilisk.gui.conversation_tab import ConversationTab
 
 	from .provider_engine.base_engine import BaseEngine
 

--- a/basilisk/screen_capture_thread.py
+++ b/basilisk/screen_capture_thread.py
@@ -8,7 +8,7 @@ from enum import Enum
 import wx
 from PIL import ImageGrab
 
-from .image_file import ImageFile
+from basilisk.conversation import ImageFile
 
 if typing.TYPE_CHECKING:
 	from io import BufferedWriter

--- a/basilisk/send_signal.py
+++ b/basilisk/send_signal.py
@@ -1,0 +1,13 @@
+import time
+
+from basilisk.consts import FOCUS_FILE, OPEN_BSKC_FILE
+
+
+def send_focus_signal():
+	with open(FOCUS_FILE, 'w') as f:
+		f.write(str(time.time()))
+
+
+def send_open_bskc_file_signal(bskc_file: str):
+	with open(OPEN_BSKC_FILE, 'w') as f:
+		f.write(bskc_file)

--- a/win_installer.iss
+++ b/win_installer.iss
@@ -6,7 +6,7 @@
     #define MyAppVersion GetVersionNumbersString('dist\basilisk.exe')
 #endif
 
-[setup]
+[Setup]
 WiZardStyle=modern
 AppVersion={#MyAppVersion}
 AppName=basiliskLLM
@@ -39,7 +39,7 @@ UsePreviousSetupType=yes
 UsePreviousTasks=yes
 ShowTasksTreeLines=no
 
-[languages]
+[Languages]
 Name: "en"; MessagesFile: "compiler:Default.isl"
 name: "french"; MessagesFile: "compiler:Languages\French.isl"
 Name: "russian"; MessagesFile: "compiler:Languages\Russian.isl"
@@ -49,9 +49,9 @@ Name: "ukrainian"; MessagesFile: "compiler:Languages\Ukrainian.isl"
 [Files]
 Source: "dist\*"; DestDir: "{app}"; Excludes: "\user_data"; Flags: recursesubdirs createallsubdirs sortfilesbyextension ignoreversion
 
-[tasks]
+[Tasks]
 Name: "DesktopIcon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
-name: "StartupIcon"; Description: "{cm:AutoStartProgram,{#SetupSetting("AppName")}}"; GroupDescription: "{cm:AutoStartProgramGroupDescription}"; Flags: unchecked
+Name: "StartupIcon"; Description: "{cm:AutoStartProgram,{#SetupSetting("AppName")}}"; GroupDescription: "{cm:AutoStartProgramGroupDescription}"; Flags: unchecked
 
 [Icons]
 Name: "{group}\{#SetupSetting("AppName")}"; Filename: "{app}\basilisk.exe"; Parameters: "-n"; WorkingDir: "{app}"; HotKey: "ctrl+alt+a"
@@ -63,6 +63,13 @@ CreateDirError=Unable to create directory: %1
 CopyFileError=Unable to copy file from: %1 to: %2
 
 
+[Registry]
+Root: HKA; subkey: "Software\Classes\.bskc"; ValueType: string; ValueName: ""; ValueData: "BasiliskLLM.File"; Flags: uninsdeletekey createvalueifdoesntexist
+Root: HKA; subkey: "Software\Classes\BasiliskLLM.File"; ValueType: string; ValueName: ""; ValueData: "BasiliskLLM conversation file"; Flags: uninsdeletekey createvalueifdoesntexist
+Root: HKA; subkey: "Software\Classes\BasiliskLLM.File"; ValueType: string; ValueName: ""; ValueData: "BasiliskLLM conversation file"; Flags: uninsdeletekey createvalueifdoesntexist; Languages: en
+Root: HKA; subkey: "Software\Classes\BasiliskLLM.File"; ValueType: string; ValueName: ""; ValueData: "Fichier de conversation basiliskLLM"; Flags: uninsdeletekey createvalueifdoesntexist; Languages: french
+Root: HKA; subkey: "Software\Classes\BasiliskLLM.File\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\basilisk.exe,0"; Flags: uninsdeletekey createvalueifdoesntexist
+Root: HKA; subkey: "Software\Classes\BasiliskLLM.File\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\basilisk.exe"" ""%1"""; Flags: uninsdeletekey createvalueifdoesntexist
 
 [Code]
 procedure CopyDirectoryTree(const SourceDir, DestDir: string);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

## New Features
- Added support for opening Basilisk Conversation (`.bskc`) files directly from the command line
- Implemented file saving and opening functionality for conversations
- Enhanced conversation management with improved file handling and storage

## Improvements
- Restructured conversation data models for better type safety and validation
- Updated file watcher to handle multiple event types
- Improved logging and error handling across various components

## Changes
- Refactored import statements and module organization
- Updated provider engine methods to use new model information structure
- Modified file and image handling mechanisms

## Technical Updates
- Added new constants for file paths and signals
- Introduced `AIModelInfo` class for better model information management
- Updated Windows installer to support `.bskc` file associations

## Bug Fixes
- Improved error handling in conversation file operations
- Enhanced image attachment and resizing logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->