### PR TITLE
fix: speak response when streaming is disabled

### DIFF
--- a/basilisk/gui/conversation_tab.py
+++ b/basilisk/gui/conversation_tab.py
@@ -822,5 +822,6 @@ class ConversationTab(wx.Panel, BaseConversation):
 		"""
 		self.conversation.add_block(new_block, system_message)
 		self.messages.display_new_block(new_block)
-		self.messages.handle_accessible_output(new_block.response.content)
+		if self.messages.should_speak_response:
+			self.messages.a_output.handle(new_block.response.content)
 		self.prompt_panel.clear()


### PR DESCRIPTION
### fix #739



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more precise control for when spoken responses are triggered, based on UI focus and visibility.

* **Refactor**
  * Renamed the "Speak stream" feature to "Speak response" throughout the interface for improved clarity.
  * Centralized and clarified the logic that determines when a response should be spoken.
  * Updated menu labels, toggle handlers, and key actions to match the new naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->