### PR TITLE
fix(conversation_tab): preserve prompt input when deleting conversation blocks

### DIFF
--- a/basilisk/gui/conversation_tab.py
+++ b/basilisk/gui/conversation_tab.py
@@ -429,7 +429,7 @@ class ConversationTab(wx.Panel, BaseConversation):
 		if need_clear:
 			self.messages.Clear()
 			if not preserve_prompt:
-				self.prompt_panel.clear(True)
+				self.prompt_panel.clear(False)
 		self.prompt_panel.refresh_attachments_list()
 		for block in self.conversation.messages:
 			self.messages.display_new_block(block)


### PR DESCRIPTION
Fixes #835


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to preserve your current prompt and attachments when refreshing or clearing a conversation, so in-progress input remains intact and you don’t need to re-enter context.

* **Bug Fixes**
  * Removing a message block no longer clears the prompt or attached files; deleted blocks won’t cause loss of your draft or uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->