### PR TITLE
ci: add explicit Inno Setup installation for windows-latest environment

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   build_windows:
-    runs-on: windows-latest
+    runs-on: windows-2025
     strategy:
       fail-fast: false
       matrix:
@@ -42,7 +42,13 @@ jobs:
             echo arch="x86" >> $env:GITHUB_OUTPUT
           }
       - name: build windows installer
-        run: iscc .\win_installer.iss /DAppArch=${{ steps.get_variables.outputs.arch }} /DMyAppVersion=${{ steps.get_variables.outputs.version_number }}
+        uses: Minionguyjpro/Inno-Setup-Action@v1.2.7
+        with:
+          path: .\win_installer.iss
+          options: |
+            /O+
+            /DAppArch=${{ steps.get_variables.outputs.arch }}
+            /DMyAppVersion=${{ steps.get_variables.outputs.version_number }}
       - name: create user config file for portable version
         run: |
           New-Item -Path dist -Name user_data -ItemType directory


### PR DESCRIPTION
GitHub has completed the migration of the `windows-latest` GitHub Actions runners from **Windows Server 2022** to **Windows Server 2025**.

On the new runners, **Inno Setup** is no longer installed by default. This PR updates our workflows to ensure they continue to run successfully in the new environment.