### PR TITLE
Add Claude Sonnet 4.5 and Opus 4.1 model support

### DIFF
--- a/basilisk/provider_engine/anthropic_engine.py
+++ b/basilisk/provider_engine/anthropic_engine.py
@@ -92,6 +92,52 @@ class AnthropicEngine(BaseEngine):
 		# See <https://docs.anthropic.com/en/docs/about-claude/models>
 		return [
 			ProviderAIModel(
+				id="claude-sonnet-4-5",
+				name="Claude Sonnet 4.5",
+				# Translators: This is a model description
+				description=_(
+					"Best model for complex agents and coding with highest intelligence"
+				),
+				context_window=200000,
+				max_output_tokens=64000,
+				vision=True,
+			),
+			ProviderAIModel(
+				id="claude-sonnet-4-5_reasoning",
+				name="Claude Sonnet 4.5 (thinking)",
+				# Translators: This is a model description
+				description=_(
+					"Best model for complex agents and coding with highest intelligence"
+				),
+				context_window=200000,
+				max_output_tokens=64000,
+				vision=True,
+				reasoning=True,
+			),
+			ProviderAIModel(
+				id="claude-opus-4-1",
+				name="Claude Opus 4.1",
+				# Translators: This is a model description
+				description=_(
+					"Exceptional model for specialized complex tasks"
+				),
+				context_window=200000,
+				max_output_tokens=32000,
+				vision=True,
+			),
+			ProviderAIModel(
+				id="claude-opus-4-1_reasoning",
+				name="Claude Opus 4.1 (thinking)",
+				# Translators: This is a model description
+				description=_(
+					"Exceptional model for specialized complex tasks"
+				),
+				context_window=200000,
+				max_output_tokens=32000,
+				vision=True,
+				reasoning=True,
+			),
+			ProviderAIModel(
 				id="claude-sonnet-4-0",
 				name="Claude Sonnet 4",
 				# Translators: This is a model description
@@ -305,9 +351,12 @@ class AnthropicEngine(BaseEngine):
 			),
 			"temperature": new_block.temperature,
 			"max_tokens": new_block.max_tokens or model.max_output_tokens,
-			"top_p": new_block.top_p,
 			"stream": new_block.stream,
 		}
+		# Only include top_p if it's not the default value (1.0)
+		# New Claude 4 models don't allow both temperature and top_p
+		if new_block.top_p != 1.0:
+			params["top_p"] = new_block.top_p
 		if system_message:
 			params["system"] = system_message.content
 		if tools:


### PR DESCRIPTION
## Link to Issue
Closes #912 

## Summary
- Add support for Claude Sonnet 4.5 and Claude Opus 4.1 models (with and without thinking mode)
- Fix API compatibility issue where Claude 4 models reject both `temperature` and `top_p` parameters

## Changes
- Added 4 new model variants to Anthropic provider:
  - Claude Sonnet 4.5 (200K context, 64K output)
  - Claude Sonnet 4.5 (thinking)
  - Claude Opus 4.1 (200K context, 32K output)
  - Claude Opus 4.1 (thinking)
- Modified completion method to only send `top_p` when it differs from default (1.0)
- All new models support vision capability

## Testing
- Verified new models appear in model selection
- Tested completion requests with default parameters (no API errors)
- Confirmed temperature/top_p conflict is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for latest Claude Sonnet 4.5 and Opus 4.1 models, including reasoning-enabled variants.
  - Enabled vision capabilities on supported models.
  - Expanded the available model list for selection.

- Bug Fixes
  - Improved parameter handling to avoid conflicts between temperature and top_p on newer models, enhancing reliability.
  - Automatically configures reasoning mode where applicable for smoother completions and consistent outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->