### PR TITLE
fix(gui): prevent duplication of first tokens in streaming responses

### DIFF
--- a/basilisk/gui/conversation_tab.py
+++ b/basilisk/gui/conversation_tab.py
@@ -832,7 +832,7 @@ class ConversationTab(wx.Panel, BaseConversation):
 			system_message: Optional system message
 		"""
 		self.conversation.add_block(new_block, system_message)
-		self.messages.display_new_block(new_block)
+		self.messages.display_new_block(new_block, streaming=True)
 		self.messages.SetInsertionPointEnd()
 
 	def _on_stream_finish(self, new_block: MessageBlock):

--- a/basilisk/gui/history_msg_text_ctrl.py
+++ b/basilisk/gui/history_msg_text_ctrl.py
@@ -139,7 +139,9 @@ class HistoryMsgTextCtrl(wx.TextCtrl):
 		segment_type=MessageSegmentType.SUFFIX,
 	)
 
-	def display_new_block(self, new_block: MessageBlock):
+	def display_new_block(
+		self, new_block: MessageBlock, streaming: bool = False
+	):
 		"""Displays a new message block in the conversation text control.
 
 		This method appends a new message block to the existing conversation, handling both request and response messages. It manages the formatting and segmentation of messages, including role labels and content.
@@ -150,9 +152,12 @@ class HistoryMsgTextCtrl(wx.TextCtrl):
 		- Uses weak references to track message blocks
 		- Preserves the original insertion point after displaying the block
 		- Supports both request and optional response messages
+		- In streaming mode, only displays the assistant label, not the content
 
 		Args:
 			new_block: The message block to be displayed in the conversation.
+			streaming: If True, indicates that the response content will be streamed
+				and should not be displayed here. Defaults to False.
 		"""
 		absolute_length = self.GetLastPosition()
 		new_block_ref = weakref.ref(new_block)
@@ -174,9 +179,12 @@ class HistoryMsgTextCtrl(wx.TextCtrl):
 				absolute_length,
 				self.role_labels[MessageRoleEnum.ASSISTANT],
 			)
-			absolute_length = self.append_content(
-				new_block_ref, absolute_length, new_block.response.content
-			)
+			# Only display response content if not streaming (streaming content
+			# is displayed incrementally via append_stream_chunk)
+			if not streaming:
+				absolute_length = self.append_content(
+					new_block_ref, absolute_length, new_block.response.content
+				)
 		self.SetInsertionPoint(pos)
 
 	def update_last_segment_length(self):


### PR DESCRIPTION
Fix issue where the first characters/tokens of assistant responses were
duplicated during streaming appearing twice).

The problem occurred because:
1. When streaming starts, display_new_block() was called to display the
   message block, including new_block.response.content
2. Due to race conditions with wx.CallAfter, streaming chunks could arrive
   and be added to new_block.response.content before _on_stream_start
   executed on the main thread
3. display_new_block() would display this accumulated content
4. Then append_stream_chunk() would display the same chunks again via
   the streaming callback, causing duplication

The fix adds a 'streaming' parameter to display_new_block() to indicate
when content is being streamed. When streaming=True, only the assistant
label is displayed (not the content), since content is displayed
incrementally via append_stream_chunk(). This ensures each chunk is
displayed exactly once.

Update _on_stream_start() to pass streaming=True when displaying the
initial block. Other call sites (refresh_messages, _on_non_stream_finish)
continue to use the default streaming=False, which is correct for
non-streaming scenarios.
