### PR TITLE
feat: improve focus restoration when restoring window from tray

### DIFF
--- a/basilisk/gui/main_frame.py
+++ b/basilisk/gui/main_frame.py
@@ -6,6 +6,7 @@ import os
 import signal
 import sys
 import tempfile
+import weakref
 from types import FrameType
 from typing import Callable, Optional
 
@@ -27,6 +28,9 @@ from .taskbar_icon import TaskBarIcon
 from .update_dialog import DownloadUpdateDialog, UpdateDialog
 
 log = logging.getLogger(__name__)
+
+# Delay (ms) before setting focus after window restore; allows window to fully appear.
+_FOCUS_RESTORE_DELAY_MS = 80
 
 
 class MainFrame(wx.Frame):
@@ -53,6 +57,9 @@ class MainFrame(wx.Frame):
 		self.conf: config.BasiliskConfig = kwargs.pop("conf", config.conf())
 		open_file = kwargs.pop("open_file", None)
 		self.last_conversation_id = 0
+		self._last_focused_before_minimize: Optional[weakref.ref[wx.Window]] = (
+			None
+		)
 		super(MainFrame, self).__init__(*args, **kwargs)
 		log.debug("Initializing main frame")
 		self.init_ui()
@@ -408,6 +415,7 @@ class MainFrame(wx.Frame):
 			self.Restore()
 			self.Layout()
 		self.Raise()
+		wx.CallLater(_FOCUS_RESTORE_DELAY_MS, self._restore_focus)
 
 	def on_minimize(self, event: wx.Event | None):
 		"""Minimize the main application frame to the system tray.
@@ -418,6 +426,9 @@ class MainFrame(wx.Frame):
 		if not self.IsShown():
 			log.debug("Already minimized")
 			return
+		focused = wx.Window.FindFocus()
+		if focused and focused.GetTopLevelParent() == self:
+			self._last_focused_before_minimize = weakref.ref(focused)
 		log.debug("Minimized to tray")
 		self.Hide()
 
@@ -433,6 +444,38 @@ class MainFrame(wx.Frame):
 		log.debug("Restored from tray")
 		self.Show(True)
 		self.Raise()
+		wx.CallLater(_FOCUS_RESTORE_DELAY_MS, self._restore_focus)
+
+	def _restore_focus(self):
+		"""Restore focus to the last focused control or a meaningful fallback."""
+		if self._last_focused_before_minimize:
+			try:
+				ctrl = self._last_focused_before_minimize()
+				if (
+					ctrl is not None
+					and ctrl.IsShown()
+					and ctrl.GetTopLevelParent() == self
+				):
+					ctrl.SetFocus()
+					return
+			except (AttributeError, RuntimeError) as e:
+				log.error("Failed to restore focus to last control: %s", e)
+			self._last_focused_before_minimize = None
+		try:
+			if (
+				self.tabs_panels
+				and self.notebook.GetSelection() != wx.NOT_FOUND
+			):
+				tab = self.tabs_panels[self.notebook.GetSelection()]
+				if tab and hasattr(tab, "prompt_panel"):
+					tab.prompt_panel.set_prompt_focus()
+					return
+		except (IndexError, AttributeError) as e:
+			log.error("Failed to restore focus to prompt: %s", e)
+		if self.panel and self.panel.IsShown():
+			self.panel.SetFocus()
+		else:
+			self.SetFocus()
 
 	def _cleanup_all_tabs(self):
 		"""Clean up resources for all conversation tabs.

--- a/basilisk/main_app.py
+++ b/basilisk/main_app.py
@@ -220,8 +220,7 @@ class MainApp(wx.App):
 		"""Brings the main application window to the front and gives it focus.
 
 		This method is called by the IPC mechanism when a focus signal is received.
-		It ensures that the main application window is brought to the front and given focus,
-		with special handling for screen readers like NVDA.
+		It ensures that the main application window is brought to the front and given focus.
 
 		The logic is:
 		1. If window is hidden -> restore it
@@ -270,9 +269,8 @@ class MainApp(wx.App):
 			log.debug("Window is iconized, restoring")
 			wx.CallAfter(self.frame.on_restore, None)
 		else:
-			# Window is visible, just force focus for screen readers
-			log.debug("Window is visible, forcing focus for screen readers")
-			wx.CallAfter(self.frame.force_focus_for_screen_reader)
+			log.debug("Window is visible, restoring focus")
+			wx.CallAfter(self.frame._restore_focus)
 
 	def init_ipc(self):
 		"""Initializes the IPC mechanism for inter-process communication."""


### PR DESCRIPTION
- Save focused control (weakref) on minimize; restore it on show
- Defer focus restore by 80ms so window is visible first
- Fall back to prompt, panel, or frame if saved control is invalid
- Add _restore_focus() used by on_restore and post_screen_capture
- IPC handler calls _restore_focus when window is already visible


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced window focus restoration when bringing the main window to the foreground and after returning from minimization
  * Focus now intelligently reverts to the previously active control with intelligent fallback mechanisms for improved UI interaction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->