### PR TITLE
fix(openrouter): detect vision capability via input_modalities field

### DIFF
--- a/basilisk/provider_engine/openrouter_engine.py
+++ b/basilisk/provider_engine/openrouter_engine.py
@@ -83,6 +83,7 @@ class OpenRouterEngine(LegacyOpenAIEngine):
 		if response.status_code == 200:
 			data = response.json()
 			for model in sorted(data["data"], key=lambda m: m["name"].lower()):
+				architecture = model.get("architecture", {})
 				extra_info = {}
 				for k, v in sorted(model.items()):
 					match k:
@@ -117,8 +118,17 @@ class OpenRouterEngine(LegacyOpenAIEngine):
 						)
 						or -1,
 						max_temperature=2.0,
-						vision="text+image->text"
-						in model.get("architecture", {}).get("modality", ""),
+						vision=(
+							"image"
+							in (
+								architecture.get("input_modalities")
+								if architecture.get("input_modalities")
+								is not None
+								else architecture.get("modality", "")
+								.split("->")[0]
+								.split("+")
+							)
+						),
 						extra_info=extra_info,
 					)
 				)


### PR DESCRIPTION
## Problem

OpenRouter API returns vision capability data in two formats depending on the model:

- **New format:** `architecture.input_modalities` — structured array, e.g. `["text", "image"]`
- **Legacy format:** `architecture.modality` — string, e.g. `"text+image->text"`

The old code checked for an exact substring `"text+image->text"` in the `modality` field.
This broke for models that use the new format or have extended modality strings like
`"text+image+file+audio+video->text"` — the substring simply wasn't found, and vision-capable
models were incorrectly treated as text-only.

## Solution

- Check `input_modalities` array first; if the field is absent, fall back to parsing
  the input side of the legacy `modality` string (`split("->")[0].split("+")`)
- In both cases, detection reduces to `"image" in <list>` — no fragile substring matching


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection of model vision capabilities by deriving image-support status from architecture metadata. Model vision support is now determined dynamically based on available input modalities rather than using static values, with fallback parsing for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->