### PR TITLE
feat(openrouter): sort models alphabetically by name

### DIFF
--- a/basilisk/provider_engine/openrouter_engine.py
+++ b/basilisk/provider_engine/openrouter_engine.py
@@ -61,6 +61,7 @@ class OpenRouterEngine(LegacyOpenAIEngine):
 		data = response.json()
 		models = parse_model_rows(data.get("data", []))
 		log.debug("Got %d models", len(models))
+		models.sort(key=lambda m: (m.name or m.id).casefold())
 		return models
 
 	def completion(

--- a/tests/provider_engine/test_openrouter_engine.py
+++ b/tests/provider_engine/test_openrouter_engine.py
@@ -36,8 +36,8 @@ def _model_row(model_id: str, created=0) -> dict:
 	}
 
 
-def test_models_sorted_by_created_desc(httpx_mock, monkeypatch, tmp_path):
-	"""OpenRouter model list is sorted by created timestamp descending."""
+def test_models_sorted_alphabetically(httpx_mock, monkeypatch, tmp_path):
+	"""OpenRouter model list is sorted alphabetically by name."""
 	httpx_mock.add_response(
 		json={
 			"data": [
@@ -50,8 +50,7 @@ def test_models_sorted_by_created_desc(httpx_mock, monkeypatch, tmp_path):
 	)
 	engine = _make_engine(monkeypatch, tmp_path)
 	models = engine.models
-	assert [model.id for model in models] == ["newer", "middle", "older"]
-	assert [model.created for model in models] == [3000, 2000, 1000]
+	assert [model.id for model in models] == ["middle", "newer", "older"]
 	for m in models:
 		assert m.extra_info["metadata_catalog"] == CATALOG_SOURCE_OPENROUTER_API
 
@@ -71,11 +70,15 @@ def test_models_invalid_created_falls_back_to_zero(
 	)
 	engine = _make_engine(monkeypatch, tmp_path)
 	models = engine.models
+	# Alphabetical order: invalid-created < valid-created
 	assert [model.id for model in models] == [
-		"valid-created",
 		"invalid-created",
+		"valid-created",
 	]
-	assert [model.created for model in models] == [42, 0]
+	assert {m.id: m.created for m in models} == {
+		"valid-created": 42,
+		"invalid-created": 0,
+	}
 
 
 def test_models_non_200_response_raises(httpx_mock, monkeypatch, tmp_path):


### PR DESCRIPTION
## Motivation

Models fetched from the OpenRouter API are returned in an arbitrary,
unspecified order. This makes it difficult to locate a specific model,
especially when browsing a long list with a screen reader (e.g. NVDA)
or when looking for models from a specific provider grouped by name.

## Changes

- Sort OpenRouter models alphabetically by `name`, falling back to `id`
  if `name` is absent
- Uses `casefold()` for case-insensitive, Unicode-aware comparison
- Updated tests to reflect the new sort order; `created` values are now
  asserted via dict (order-independent) where relevant

## Notes

Alphabetical order is the standard UX expectation for model selection
lists and makes navigation consistent and predictable across sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* OpenRouter provider models are now sorted alphabetically by name instead of by creation date, making them easier to browse and locate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->